### PR TITLE
Breaking: Rename Socrative orange to amber

### DIFF
--- a/src/backpack-socrative.js
+++ b/src/backpack-socrative.js
@@ -16,7 +16,7 @@ export const colors = {
 
   red: SHOWBIE.red,
 
-  orange: {
+  amber: {
     50: '#fff7e5',
     100: '#fff0ce',
     200: '#ffe9b7',


### PR DESCRIPTION
Makes room in the spectrum for a more strictly `orange` hue.